### PR TITLE
add clearing out matchloads for orange auton

### DIFF
--- a/src/config/orange/autons.cpp
+++ b/src/config/orange/autons.cpp
@@ -65,6 +65,24 @@ void auton1() {
     pros::delay(3000);
     subsystems::intake::stop();
 
+     // Drive back to matchloader
+    subsystems::intake::score_long();
+    chassis.pid_drive_set(27_in,SLOW_SPEED, true);
+    chassis.pid_wait_until(10_in);
+    subsystems::matchloader->extend();
+    chassis.pid_wait();
+
+    // Intake and outtake all unwanted blocks
+    for(int i = 0; i < 3; i++){
+        chassis.pid_drive_set(3_in, MAX_SPEED);
+        chassis.pid_wait();
+        chassis.pid_drive_set(-3_in, MAX_SPEED);
+        chassis.pid_wait();
+    }
+    chassis.pid_drive_set(3_in, MAX_SPEED);
+    chassis.pid_wait();
+    subsystems::intake::stop();
+
 
 }
 


### PR DESCRIPTION
Auburn comp 5 am cook. Will it work? Who knows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Enhanced auton1 routine now automatically returns to the matchloader area after long scoring
- Added block clearance sequence with back-and-forth drive movements to remove unwanted blocks
- Extended autonomous flow with integrated matchloader operations during recovery cycle
- Robot now executes a complete scoring-and-recovery sequence in a single autonomous mode

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->