### PR TITLE
Changes for Orange Auton and Orange Piston Config

### DIFF
--- a/include/config/orange/autons.hpp
+++ b/include/config/orange/autons.hpp
@@ -6,6 +6,9 @@ void add_autons();
 namespace orange {
 
 void auton1();
+
+void skills();
+
 // Add more auton routine declarations here
 
 }  // namespace orange

--- a/include/config/orange/config.hpp
+++ b/include/config/orange/config.hpp
@@ -75,7 +75,7 @@ struct Controls {
 
     static constexpr pros::controller_digital_e_t wing              = pros::E_CONTROLLER_DIGITAL_RIGHT;
     static constexpr pros::controller_digital_e_t hood              = pros::E_CONTROLLER_DIGITAL_UP;
-    static constexpr pros::controller_digital_e_t matchloader       = pros::E_CONTROLLER_DIGITAL_Y;
+    static constexpr pros::controller_digital_e_t matchloader       = pros::E_CONTROLLER_DIGITAL_B;
 };
 
 }  // namespace robot

--- a/include/config/orange/ports.hpp
+++ b/include/config/orange/ports.hpp
@@ -11,7 +11,7 @@ inline constexpr std::int8_t DRIVE_RIGHT_REAR       = 19;
 inline constexpr std::int8_t DRIVE_RIGHT_AUX        = 20;
 
 inline constexpr std::int8_t DRIVE_LEFT_FRONT       = -13;
-inline constexpr std::int8_t DRIVE_LEFT_MIDDLE      = 14;
+inline constexpr std::int8_t DRIVE_LEFT_MIDDLE      = 15;
 inline constexpr std::int8_t DRIVE_LEFT_REAR        = -12;
 inline constexpr std::int8_t DRIVE_LEFT_AUX         = -11;
 
@@ -28,7 +28,7 @@ inline constexpr std::int8_t PISTON_WING            = 'C';
 inline constexpr std::int8_t PISTON_HOOD            = 'B';
 
 // Sensors
-inline constexpr std::int8_t IMU                    = 0;
+inline constexpr std::int8_t IMU                    = 14;
 inline constexpr std::int8_t VERTICAL_ROTATION      = 0;
 inline constexpr std::int8_t HORIZONTAL_ROTATION    = 0;
 inline constexpr std::int8_t OPTICAL_COLOR_SORT     = 0;

--- a/src/config/orange/autons.cpp
+++ b/src/config/orange/autons.cpp
@@ -14,27 +14,32 @@ namespace orange {
 void auton1() {
    
     // Open Hood
-    subsystems::hood->extend();
+    subsystems::hood->retract();
 
     // Drive Forwards
-    chassis.pid_drive_set(32_in, DRIVE_SPEED, true);
+    chassis.pid_drive_set(55_in, DRIVE_SPEED, true);
     chassis.pid_wait();
 
     // Align with middle goal
-    chassis.pid_turn_set(-45, TURN_SPEED, true);
+    chassis.pid_turn_set(-35, TURN_SPEED, true);
     chassis.pid_wait();
 
     // Drive Forwards into lower middle goal
-    chassis.pid_drive_set(7_in, SLOW_SPEED, true);
+    chassis.pid_drive_set(4_in, SLOW_SPEED, true);
     chassis.pid_wait();
 
     // Score middle 
     subsystems::intake::reverse();
     pros::delay(1000);
     subsystems::intake::stop();
+
+    // Align with middle goal
+    chassis.pid_turn_set(-50, TURN_SPEED, true);
+    chassis.pid_wait();
+
     // Drive to matchloader
-    chassis.pid_drive_set(-51_in, DRIVE_SPEED, true);
-    chassis.pid_wait_until(-40_in);
+    chassis.pid_drive_set(-80_in, DRIVE_SPEED, true);
+    chassis.pid_wait_until(-83_in);
     subsystems::matchloader->extend();
     chassis.pid_wait();
 
@@ -43,19 +48,19 @@ void auton1() {
 
     // Drive into matchloader
     subsystems::intake::collect();
-    chassis.pid_drive_set(15_in, SLOW_SPEED, true);
+    chassis.pid_drive_set(17_in, 80, true);
     chassis.pid_wait();
 
-    for(int i = 0; i < 3; i++){
-        chassis.pid_drive_set(3_in, MAX_SPEED);
+    for(int i = 0; i < 4; i++){
+        chassis.pid_drive_set(7_in, MAX_SPEED);
         chassis.pid_wait();
-        chassis.pid_drive_set(-3_in, MAX_SPEED);
+        chassis.pid_drive_set(-7_in, MAX_SPEED);
         chassis.pid_wait();
     }
     subsystems::intake::stop();
 
     // Drive to long goal
-    chassis.pid_drive_set(-27_in, DRIVE_SPEED, true);
+    chassis.pid_drive_set(-35_in, DRIVE_SPEED, true);
     chassis.pid_wait_until(-10_in);
     subsystems::matchloader->retract();
     chassis.pid_wait();
@@ -64,7 +69,13 @@ void auton1() {
     subsystems::intake::score_long();
     pros::delay(3000);
     subsystems::intake::stop();
+ 
 
+}
+
+void skills(){
+
+    subsystems::intake::reverse();
 
 }
 

--- a/src/config/orange/config_autons.cpp
+++ b/src/config/orange/config_autons.cpp
@@ -10,7 +10,7 @@
 
 void default_constants() {
   // P, I, D, and Start I
-  chassis.pid_drive_constants_set(20.0, 0.0, 100.0);         // Fwd/rev constants, used for odom and non odom motions
+  chassis.pid_drive_constants_set(19.4, 0.0, 109.00);        // Fwd/rev constants, used for odom and non odom motions
   chassis.pid_heading_constants_set(11.0, 0.0, 20.0);        // Holds the robot straight while going forward without odom
   chassis.pid_turn_constants_set(3.0, 0.05, 20.0, 15.0);     // Turn in place constants
   chassis.pid_swing_constants_set(6.0, 0.0, 65.0);           // Swing constants
@@ -26,25 +26,6 @@ void default_constants() {
   chassis.pid_turn_chain_constant_set(3_deg);
   chassis.pid_swing_chain_constant_set(5_deg);
   chassis.pid_drive_chain_constant_set(3_in);
-
-  /* High Stakes PID values
-  // P, I, D, and Start I
-  chassis.pid_drive_constants_set(19.4, 0.0, 109.00);         // Fwd/rev constants, used for odom and non odom motions
-  chassis.pid_heading_constants_set(10.7, 0.0, 21.0);        // Holds the robot straight while going forward without odom
-  chassis.pid_turn_constants_set(3.3, 0, 28.75, 0);     // Turn in place constants
-  chassis.pid_swing_constants_set(6.0, 0.0, 65.0);           // Swing constants
-  chassis.pid_odom_angular_constants_set(6.5, 0.0, 52.5);    // Angular control for odom motions
-  chassis.pid_odom_boomerang_constants_set(5.8, 0.0, 32.5);  // Angular control for boomerang motions
-
-  // Exit conditions
-  chassis.pid_turn_exit_condition_set(200_ms, 1.5_deg, 350_ms, 5_deg, 500_ms, 500_ms);
-  chassis.pid_swing_exit_condition_set(90_ms, 3_deg, 250_ms, 5_deg, 500_ms, 500_ms);
-  chassis.pid_drive_exit_condition_set(90_ms, 1_in, 250_ms, 3_in, 500_ms, 500_ms);
-  chassis.pid_odom_turn_exit_condition_set(90_ms, 3_deg, 250_ms, 5_deg, 500_ms, 750_ms);
-  chassis.pid_odom_drive_exit_condition_set(90_ms, 0.5_in, 250_ms, 3_in, 500_ms, 750_ms);
-  chassis.pid_turn_chain_constant_set(3_deg);
-  chassis.pid_swing_chain_constant_set(5_deg);
-  chassis.pid_drive_chain_constant_set(3_in); */
 
   // Slew constants
   chassis.slew_turn_constants_set(3_deg, 70);
@@ -69,6 +50,7 @@ void add_autons() {
     // Autonomous Selector using LLEMU
     ez::as::auton_selector.autons_add({
         {"Auburn Car Auto", orange::auton1},
+        {"Orange Skills", orange::skills},
         // Add more autons here
         // {"Orange Auton 2", orange::auton2},
     });


### PR DESCRIPTION
**DO NOT just merge this pull request!!!**

This pull request includes code that changes the piston state for BOTH ROBOTS.

This needed to be fixed so that the orange robot could stay in size for the comp, but the change needs to be fixed. I've opened an issue to fix this, and it should be an easy fix but merging this code straight to main will cause issues for both bots.

Side note: Orange auton will be pretty much useless since the PID values are not correct and the drivetrain does not drive straight. Later down the line we can mirror the blue auton for orange, but this is what we "cooked" up at competition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Orange Skills autonomous routine for competition selection

* **Configuration**
  * Updated autonomous movement sequences including drive distances and turn angles
  * Changed controller button mapping for matchloader mechanism
  * Adjusted sensor port assignments
  * Refined drive control tuning parameters
<!-- end of auto-generated comment: release notes by coderabbit.ai -->