### PR TITLE
Updated Piston API. CLOSES: #32

### DIFF
--- a/include/config/blue/config.hpp
+++ b/include/config/blue/config.hpp
@@ -74,7 +74,6 @@ struct Controls {
     static constexpr pros::controller_digital_e_t score_middle_goal = pros::E_CONTROLLER_DIGITAL_R2;
 
     static constexpr pros::controller_digital_e_t wing              = pros::E_CONTROLLER_DIGITAL_RIGHT;
-    static constexpr pros::controller_digital_e_t hood              = (pros::controller_digital_e_t)(-1);
     static constexpr pros::controller_digital_e_t matchloader       = pros::E_CONTROLLER_DIGITAL_Y;
 };
 

--- a/include/config/blue/ports.hpp
+++ b/include/config/blue/ports.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <utility>
 
 namespace robot {
 namespace ports {
@@ -21,11 +22,10 @@ inline constexpr std::int8_t INTAKE_BOTTOM_STAGE_2  = -10;
 inline constexpr std::int8_t INTAKE_TOP_STAGE       = 19;
 inline constexpr std::int8_t INTAKE_INDEXER         = 12;
 
-// Pneumatics
-inline constexpr std::int8_t PISTON_MATCHLOADER     = 'A';
-inline constexpr std::int8_t PISTON_INDEXER         = 'B';
-inline constexpr std::int8_t PISTON_WING            = 'C';
-inline constexpr std::int8_t PISTON_HOOD            = 'D';
+// Pneumatics (port, reversed)
+inline constexpr std::pair<std::int8_t, bool> PISTON_MATCHLOADER = {'A', false};
+inline constexpr std::pair<std::int8_t, bool> PISTON_INDEXER     = {'B', false};
+inline constexpr std::pair<std::int8_t, bool> PISTON_WING        = {'C', false};
 
 // Sensors
 inline constexpr std::int8_t IMU                    = 18;

--- a/include/config/orange/ports.hpp
+++ b/include/config/orange/ports.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <utility>
 
 namespace robot {
 namespace ports {
@@ -21,11 +22,11 @@ inline constexpr std::int8_t INTAKE_BOTTOM_STAGE_2  = 1;
 inline constexpr std::int8_t INTAKE_TOP_STAGE       = 9;
 inline constexpr std::int8_t INTAKE_INDEXER         = 2;
 
-// Pneumatics
-inline constexpr std::int8_t PISTON_MATCHLOADER     = 'D';
-inline constexpr std::int8_t PISTON_INDEXER         = 'A';
-inline constexpr std::int8_t PISTON_WING            = 'C';
-inline constexpr std::int8_t PISTON_HOOD            = 'B';
+// Pneumatics (port, reversed)
+inline constexpr std::pair<std::int8_t, bool> PISTON_MATCHLOADER = {'D', false};
+inline constexpr std::pair<std::int8_t, bool> PISTON_INDEXER     = {'A', false};
+inline constexpr std::pair<std::int8_t, bool> PISTON_WING        = {'C', false};
+inline constexpr std::pair<std::int8_t, bool> PISTON_HOOD        = {'B', true};
 
 // Sensors
 inline constexpr std::int8_t IMU                    = 14;

--- a/include/core/globals.hpp
+++ b/include/core/globals.hpp
@@ -33,6 +33,8 @@ extern pros::Motor intake_indexer;
 extern pros::adi::Pneumatics piston_matchloader;
 extern pros::adi::Pneumatics piston_indexer;
 extern pros::adi::Pneumatics piston_wing;
+#ifdef ROBOT_ORANGE
 extern pros::adi::Pneumatics piston_hood;
+#endif
 
 }  // namespace globals

--- a/include/core/subsystems/pistons.hpp
+++ b/include/core/subsystems/pistons.hpp
@@ -3,6 +3,7 @@
 #include "pros/adi.hpp"
 #include "pros/misc.hpp"
 
+#include <memory>
 #include <optional>
 
 namespace subsystems {
@@ -40,12 +41,38 @@ private:
 // Initialize all pistons (call from main initialize())
 void initialize();
 
+// Safe helper functions for pistons (check nullptr before calling)
+// Use these for all piston calls to maintain consistent API
+inline void safe_extend(const std::unique_ptr<Piston>& piston) {
+    if (piston != nullptr) {
+        piston->extend();
+    }
+}
+
+inline void safe_retract(const std::unique_ptr<Piston>& piston) {
+    if (piston != nullptr) {
+        piston->retract();
+    }
+}
+
+inline void safe_toggle(const std::unique_ptr<Piston>& piston) {
+    if (piston != nullptr) {
+        piston->toggle();
+    }
+}
+
+inline void safe_update(const std::unique_ptr<Piston>& piston) {
+    if (piston != nullptr) {
+        piston->update();
+    }
+}
+
 }  // namespace pistons
 
 // Global piston instances (initialized after subsystems::pistons::initialize() is called)
-extern pistons::Piston* indexer;
-extern pistons::Piston* matchloader;
-extern pistons::Piston* wing;
-extern pistons::Piston* hood;
+extern std::unique_ptr<pistons::Piston> indexer;
+extern std::unique_ptr<pistons::Piston> matchloader;
+extern std::unique_ptr<pistons::Piston> wing;
+extern std::unique_ptr<pistons::Piston> hood;
 
 }  // namespace subsystems

--- a/src/config/blue/autons.cpp
+++ b/src/config/blue/autons.cpp
@@ -31,7 +31,7 @@ void match_auton() {
     // Drive to matchloader
     chassis.pid_drive_set(51_in, DRIVE_SPEED, true);
     chassis.pid_wait_until(40_in);
-    subsystems::matchloader->extend();
+    subsystems::pistons::safe_extend(subsystems::matchloader);
     chassis.pid_wait();
 
     chassis.pid_turn_set(0_deg, TURN_SPEED, true);

--- a/src/config/orange/autons.cpp
+++ b/src/config/orange/autons.cpp
@@ -12,7 +12,7 @@ namespace orange {
 
 void match_auton() {
     // Open Hood
-    subsystems::hood->extend();
+    subsystems::pistons::safe_extend(subsystems::hood);
 
     // Drive Forwards
     chassis.pid_drive_set(55_in, DRIVE_SPEED, true);
@@ -38,7 +38,7 @@ void match_auton() {
     // Drive to matchloader
     chassis.pid_drive_set(-80_in, DRIVE_SPEED, true);
     chassis.pid_wait_until(-83_in);
-    subsystems::matchloader->extend();
+    subsystems::pistons::safe_extend(subsystems::matchloader);
     chassis.pid_wait();
 
     chassis.pid_turn_set(180_deg, TURN_SPEED, true);
@@ -60,7 +60,7 @@ void match_auton() {
     // Drive to long goal
     chassis.pid_drive_set(-35_in, DRIVE_SPEED, true);
     chassis.pid_wait_until(-10_in);
-    subsystems::matchloader->retract();
+    subsystems::pistons::safe_retract(subsystems::matchloader);
     chassis.pid_wait();
 
     // Score long

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -51,9 +51,11 @@ pros::Motor intake_indexer(robot::ports::INTAKE_INDEXER);
 pros::Optical optical_color_sort(robot::ports::OPTICAL_COLOR_SORT);
 
 // Pneumatics
-pros::adi::Pneumatics piston_matchloader(robot::ports::PISTON_MATCHLOADER, false);
-pros::adi::Pneumatics piston_indexer(robot::ports::PISTON_INDEXER, false);
-pros::adi::Pneumatics piston_wing(robot::ports::PISTON_WING, false);
-pros::adi::Pneumatics piston_hood(robot::ports::PISTON_HOOD, false);
+pros::adi::Pneumatics piston_matchloader(robot::ports::PISTON_MATCHLOADER.first, false);
+pros::adi::Pneumatics piston_indexer(robot::ports::PISTON_INDEXER.first, false);
+pros::adi::Pneumatics piston_wing(robot::ports::PISTON_WING.first, false);
+#ifdef ROBOT_ORANGE
+pros::adi::Pneumatics piston_hood(robot::ports::PISTON_HOOD.first, false);
+#endif
 
 }  // namespace globals

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -87,20 +87,20 @@ void opcontrol() {
     // Set drive brake mode to coast for opcontrol
     chassis.drive_brake_set(pros::E_MOTOR_BRAKE_COAST);
 
-    // Ensure hood is open
-    subsystems::hood->extend();
+    // Ensure hood is open (if present)
+    subsystems::pistons::safe_extend(subsystems::hood);
 
     // Ensure matchloader is closed
-    subsystems::matchloader->retract();
+    subsystems::pistons::safe_retract(subsystems::matchloader);
 
     while (true) {
         // Run the drive mode
         subsystems::drive::chassis_controller(ez::SPLIT);
 
         // Update piston states based on controller input
-        subsystems::matchloader->update();
-        subsystems::wing->update();
-        subsystems::hood->update();
+        subsystems::pistons::safe_update(subsystems::matchloader);
+        subsystems::pistons::safe_update(subsystems::wing);
+        subsystems::pistons::safe_update(subsystems::hood);
         
         // Small delay to prevent task from consuming too much CPU
         pros::delay(core::util::DELAY_TIME);

--- a/src/core/subsystems/intake.cpp
+++ b/src/core/subsystems/intake.cpp
@@ -78,42 +78,42 @@ void apply_state(IntakeState state) {
             set_bottom_power(0);
             set_top_power(0);
             set_indexer_power(0);
-            indexer->retract();
+            subsystems::pistons::safe_retract(subsystems::indexer);
             break;
 
         case IntakeState::SCORE_LONG:
             set_bottom_power(INTAKE_SPEED);
             set_top_power(INTAKE_SPEED);
             set_indexer_power(INTAKE_SPEED);
-            indexer->retract();
+            subsystems::pistons::safe_retract(subsystems::indexer);
             break;
 
         case IntakeState::SCORE_SLOW:
             set_bottom_power(INTAKE_SPEED_SLOW);
             set_top_power(INTAKE_SPEED_SLOW);
             set_indexer_power(INTAKE_SPEED_SLOW);
-            indexer->retract();
+            subsystems::pistons::safe_retract(subsystems::indexer);
             break;
 
         case IntakeState::SCORE_MIDDLE:
             set_bottom_power(INTAKE_SPEED);
             set_top_power(INTAKE_SPEED);
             set_indexer_power(-INTAKE_SPEED);
-            indexer->extend();
+            subsystems::pistons::safe_extend(subsystems::indexer);
             break;
 
         case IntakeState::COLLECT:
             set_bottom_power(INTAKE_SPEED);
             set_top_power(0);
             set_indexer_power(0);
-            indexer->retract();
+            subsystems::pistons::safe_retract(subsystems::indexer);
             break;
 
         case IntakeState::REVERSE:
             set_bottom_power(-INTAKE_SPEED);
             set_top_power(-INTAKE_SPEED);
             set_indexer_power(-INTAKE_SPEED);
-            indexer->retract();
+            subsystems::pistons::safe_retract(subsystems::indexer);
             break;
     }
 }

--- a/src/core/subsystems/pistons.cpp
+++ b/src/core/subsystems/pistons.cpp
@@ -55,18 +55,22 @@ bool Piston::is_extended() const {
 }
 
 void initialize() {
-    indexer     = new Piston(globals::piston_indexer); // No button - yielding control to intake subsystem
-    matchloader = new Piston(globals::piston_matchloader, robot::Controls::matchloader, PistonMode::HOLD);
-    wing        = new Piston(globals::piston_wing, robot::Controls::wing, PistonMode::HOLD);
-    hood        = new Piston(globals::piston_hood, robot::Controls::hood, PistonMode::TOGGLE, true);
+    indexer     = std::make_unique<Piston>(globals::piston_indexer, std::nullopt, PistonMode::HOLD, robot::ports::PISTON_INDEXER.second);  // No button - yielding control to intake subsystem
+    matchloader = std::make_unique<Piston>(globals::piston_matchloader, robot::Controls::matchloader, PistonMode::HOLD, robot::ports::PISTON_MATCHLOADER.second);
+    wing        = std::make_unique<Piston>(globals::piston_wing, robot::Controls::wing, PistonMode::HOLD, robot::ports::PISTON_WING.second);
+#ifdef ROBOT_ORANGE
+    hood        = std::make_unique<Piston>(globals::piston_hood, robot::Controls::hood, PistonMode::TOGGLE, robot::ports::PISTON_HOOD.second);
+#else
+    hood        = nullptr;  // Blue robot hood piston is not used
+#endif
 }
 
 }  // namespace pistons
 
 // Global piston pointers (nullptr until subsystems::pistons::initialize() is called)
-pistons::Piston* indexer     = nullptr;
-pistons::Piston* matchloader = nullptr;
-pistons::Piston* wing        = nullptr;
-pistons::Piston* hood        = nullptr;
+std::unique_ptr<pistons::Piston> indexer     = nullptr;
+std::unique_ptr<pistons::Piston> matchloader = nullptr;
+std::unique_ptr<pistons::Piston> wing        = nullptr;
+std::unique_ptr<pistons::Piston> hood        = nullptr;
 
 }  // namespace subsystems


### PR DESCRIPTION
# Refactor Piston Configuration and Make Hood Optional

## Changes

- **Moved piston reverse configuration to ports**: Changed piston port definitions from `std::int8_t` to `std::pair<std::int8_t, bool>` to allow configurable reversed state per robot
- **Made hood optional for ROBOT_BLUE**: Added conditional compilation guards so hood piston is only initialized/used for ROBOT_ORANGE
- **Refactored to smart pointers**: Replaced raw pointers with `std::unique_ptr` to prevent memory leaks and follow modern C++ practices
- **Unified piston API**: Created `safe_extend()`, `safe_retract()`, `safe_update()`, and `safe_toggle()` helper functions for consistent piston access throughout the codebase

## Benefits

- Piston reverse configuration is now in config files, making it easier to adjust per robot
- Cleaner runtime code without scattered `#ifdef` guards
- Automatic memory management with smart pointers
- Consistent API for all piston operation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated piston control system with added safety mechanisms to prevent invalid operations.
  * Blue robot: Removed hood control functionality.
  * Orange robot: Hood control remains available.
  * Improved internal piston handling with safer operation wrappers across all autonomous routines and drive control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->